### PR TITLE
fix(ci): trust committed pnpm lockfile

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm --config.trust-lockfile=true install --frozen-lockfile
 
       - run: pnpm run lint
       - run: pnpm run typecheck


### PR DESCRIPTION
## 修复

- 在 CI 中信任仓库已提交的 pnpm 锁文件
- 保留 `--frozen-lockfile`，依赖清单与锁文件不一致时仍会失败
- 避免 pnpm 11 对受信任锁文件重复执行发布时间窗口校验

## 验证

- pnpm 11.15.1 命令格式已验证
- 工作流 YAML 解析通过
- `git diff --check`